### PR TITLE
add link to marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Go Companion
 
-An unofficial companion to the [official Go extension][vscode-go-ms] that
+The [unofficial VS Code Go companion][vscode-go-companion] to the [official Go extension][vscode-go-ms] that
 provides experimental features.
 
 [vscode-go-ms]: https://marketplace.visualstudio.com/items?itemName=golang.go
+[vscode-go-companion]: https://marketplace.visualstudio.com/items?itemName=ethan-reesor.exp-vscode-go
 
 ## Issues
 
@@ -43,7 +44,7 @@ To profile tests:
 7. There will now be a `Profiles` item under the test
 8. Open `Profiles`
 9. Open the profile set, e.g. `12:34:56`
-10. Open the profile, e.g. `CPU`, by double clicking the item or clicking the open symbol
+10. Open the profile, e.g. `CPU`, by double-clicking the item or clicking the open symbol
 
 ![profiles](./docs/assets/profile-items.png)
 
@@ -55,7 +56,7 @@ the package instead of the individual test.
 ## Documentation Viewer
 
 Go Companion provides a command and editor context menu item for rendering
-package documentation. Right click a declaration in a Go file and select "Go
+package documentation. Right-click a declaration in a Go file and select "Go
 Companion: Render Documentation":
 
 ![doc-viewer](./docs/assets/doc-viewer.png)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To profile tests:
 7. There will now be a `Profiles` item under the test
 8. Open `Profiles`
 9. Open the profile set, e.g. `12:34:56`
-10. Open the profile, e.g. `CPU`, by double-clicking the item or clicking the open symbol
+10. Open the profile, e.g. `CPU`, by double clicking the item or clicking the open symbol
 
 ![profiles](./docs/assets/profile-items.png)
 
@@ -56,7 +56,7 @@ the package instead of the individual test.
 ## Documentation Viewer
 
 Go Companion provides a command and editor context menu item for rendering
-package documentation. Right-click a declaration in a Go file and select "Go
+package documentation. Right click a declaration in a Go file and select "Go
 Companion: Render Documentation":
 
 ![doc-viewer](./docs/assets/doc-viewer.png)


### PR DESCRIPTION
- **Add link to the Markeplace**
- **Minor stylistic improvement in the README**

I replicated the way the official Go VS Code extension does to provide a link to the Marketplace

https://github.com/golang/vscode-go

I can adapt of course
