### PR TITLE
Enable test explorer conditionally based on Go extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Next
+
+- Disable the test explorer by default when using a non-prerelease version of
+  vscode-go.
+
 ## v0.0.7
 
 - A better workaround for [microsoft/vscode#242124][vsc-242124].

--- a/package.json
+++ b/package.json
@@ -57,10 +57,23 @@
       "properties": {
         "exp-vscode-go.testExplorer.enable": {
           "order": 0,
-          "type": "boolean",
-          "default": true,
+          "type": [
+            "string",
+            "boolean"
+          ],
+          "default": "auto",
           "scope": "window",
-          "markdownDescription": "Enable the Go test explorer"
+          "markdownDescription": "Enable the Go test explorer. By default the test explorer is enabled if the Go extension is a prerelease version and disabled otherwise.",
+          "enum": [
+            true,
+            false,
+            "auto"
+          ],
+          "enumItemLabels": [
+            "Enable",
+            "Disable",
+            "Automatic"
+          ]
         },
         "exp-vscode-go.testExplorer.discovery": {
           "order": 1,

--- a/src/test/register.ts
+++ b/src/test/register.ts
@@ -1,12 +1,22 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { commands, ExtensionContext, ExtensionMode, TestItem, tests, window, workspace } from 'vscode';
-import { Context, helpers } from '../utils/testing';
 import { GoExtensionAPI } from '../vscode-go';
 import { debugProcess, spawnProcess } from './utils';
 import { TestManager } from './manager';
-import { languages } from 'vscode';
+import {
+	commands,
+	ExtensionContext,
+	ExtensionMode,
+	extensions,
+	languages,
+	Memento,
+	TestItem,
+	tests,
+	window,
+	workspace,
+} from 'vscode';
 import { Browser } from '../browser';
 import { registerProfileEditor } from './profile';
+import { Context, helpers } from '../utils/testing';
 
 export async function registerTestingFeatures(ctx: ExtensionContext, go: GoExtensionAPI) {
 	const testCtx: Context = {
@@ -44,6 +54,18 @@ async function registerTestController(ctx: ExtensionContext, testCtx: Context) {
 	};
 	ctx.subscriptions.push(manager);
 
+	const maybeChangedEnabled = async () => {
+		const enabled = await isEnabled(ctx.globalState);
+		if (enabled === manager.enabled) {
+			return;
+		}
+		if (enabled) {
+			await setup();
+		} else {
+			manager.dispose();
+		}
+	};
+
 	// [Command] Refresh
 	command('goExp.testExplorer.refresh', (item: TestItem) => manager.enabled && manager.reloadViewItem(item));
 
@@ -62,15 +84,7 @@ async function registerTestController(ctx: ExtensionContext, testCtx: Context) {
 	// [Event] Configuration change
 	event(workspace.onDidChangeConfiguration, 'changed configuration', async (e) => {
 		if (e.affectsConfiguration('exp-vscode-go.testExplorer.enable')) {
-			const enabled = workspace.getConfiguration('exp-vscode-go').get<boolean>('testExplorer.enable');
-			if (enabled === manager.enabled) {
-				return;
-			}
-			if (enabled) {
-				await setup();
-			} else {
-				manager.dispose();
-			}
+			await maybeChangedEnabled();
 		}
 		if (!manager.enabled) {
 			return;
@@ -85,6 +99,11 @@ async function registerTestController(ctx: ExtensionContext, testCtx: Context) {
 		) {
 			await manager.reloadView();
 		}
+	});
+
+	// [Event] Extensions changed
+	event(extensions.onDidChange, 'changed extensions', async () => {
+		await maybeChangedEnabled();
 	});
 
 	// [Event] File open
@@ -126,7 +145,55 @@ async function registerTestController(ctx: ExtensionContext, testCtx: Context) {
 	event(watcher.onDidDelete, 'deleted file', async (e) => manager.enabled && manager.reloadUri(e));
 
 	// Setup the controller (if enabled)
-	if (workspace.getConfiguration('exp-vscode-go').get<boolean>('testExplorer.enable')) {
+	if (await isEnabled(ctx.globalState)) {
 		await setup();
+	}
+}
+
+async function isEnabled(state: Memento) {
+	// If the user has explicitly enabled or disabled the test explorer, use
+	// that.
+	const enabled = workspace.getConfiguration('exp-vscode-go').get<boolean | 'auto'>('testExplorer.enable');
+	if (typeof enabled === 'boolean') {
+		return enabled;
+	}
+
+	// Default to enabled if the Go extension is in preview mode. Re-fetch the
+	// extension API in case the extension has been changed.
+	const go = await extensions.getExtension<GoExtensionAPI>('golang.go')?.activate();
+	if (go?.isPreview === true) {
+		return true;
+	}
+
+	notifyUser(state);
+	return false;
+}
+
+/**
+ * Notify the user that we're enabling the experimental explorer.
+ */
+async function notifyUser(state: Memento) {
+	// If the user has acknowledged the notification, don't show it again.
+	const id = 'testExplorer.didAckDisableNotification';
+	if (state.get(id) === true) {
+		return;
+	}
+
+	const r = await window.showInformationMessage(
+		"Go Companion's test explorer is disabled by default when the Go extension is not a prerelease version. Override this by setting goExp.testExplorer.enable to true.",
+		'Open settings',
+		'Ok',
+	);
+
+	switch (r) {
+		case 'Open settings':
+			await commands.executeCommand('workbench.action.openSettings2', {
+				query: 'goExp.testExplorer.enable',
+			});
+			break;
+
+		case 'Ok':
+			state.update(id, true);
+			break;
 	}
 }

--- a/src/vscode-go.d.ts
+++ b/src/vscode-go.d.ts
@@ -58,6 +58,9 @@ export interface CommandInvocation {
 }
 
 export interface GoExtensionAPI {
+	/** True if the extension is running in preview mode (e.g. prerelease) */
+	isPreview?: boolean;
+
 	settings: {
 		/**
 		 * Returns the execution command corresponding to the specified resource, taking into account


### PR DESCRIPTION
This can be merged after [vscode-go CL 653115](https://go-review.googlesource.com/c/vscode-go/+/653115) is merged. Closes golang/vscode-go#3651.